### PR TITLE
feat(plugin): support private repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ You should set `repo` in your `book.json`.
 }
 ```
 
+- `private`: `boolean` (optional, default is `false`)
+
+For private repositories, set this flag.
+
+```json
+{
+    "gitbook": ">=3.0.0",
+    "title": "Example",
+    "plugins": [
+        "github-issue-feedback"
+    ],
+    "pluginsConfig": {
+        "github-issue-feedback": {
+            "repo": "your/private_repo",
+            "private": true
+        }
+    }
+}
+```
+
 ## Changelog
 
 See [Releases page](https://github.com/azu/gitbook-plugin-github-issue-feedback/releases).

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 
 const path = require("path")
 const fse = require("fs-extra")
-const pkg = require("./package.json")
 
 module.exports = {
     website: {
@@ -24,7 +23,7 @@ module.exports = {
             // copy contents for private repository
             if (isPrivateRepo) {
                 const source = this.config.get("root", "./")
-                const target = path.join("./_book/gitbook/", pkg.name, "contents", source)
+                const target = path.join("./_book/gitbook/gitbook-plugin-github-issue-feedback/contents", source)
                 fse.copy(source, target)
             }
         }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,32 @@
 // MIT © 2017 azu
 "use strict";
+
+const path = require("path")
+const fse = require("fs-extra")
+const pkg = require("./package.json")
+
 module.exports = {
     website: {
         assets: "./assets",
         js: [
             "plugin.js"
         ]
+    },
+    hooks: {
+        finish: function() {
+            // check configuration
+            const pluginsConfig = this.config.get("pluginsConfig")
+            const isPrivateRepo =
+                pluginsConfig !== undefined &&
+                pluginsConfig["github-issue-feedback"] !== undefined &&
+                pluginsConfig["github-issue-feedback"].private === true
+
+            // copy contents for private repository
+            if (isPrivateRepo) {
+                const source = this.config.get("root", "./")
+                const target = path.join("./_book/gitbook/", pkg.name, "contents", source)
+                fse.copy(source, target)
+            }
+        }
     }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
         "type": "string",
         "description": "GitHub API Base url e.g.) https://api.github.com/repos/asciidwango/js-primer/blob/master/",
         "required": false
+      },
+      "private": {
+        "type": "boolean",
+        "description": "Is repo private or not?",
+        "required": false
       }
     }
   },
@@ -76,6 +81,7 @@
     "webpack": "^2.6.1"
   },
   "dependencies": {
+    "fs-extra": "^5.0.0",
     "position-map-text-to-markdown": "^1.0.1",
     "url-join": "^2.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,6 +1350,14 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1437,7 +1445,7 @@ globals@^9.0.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1770,6 +1778,12 @@ json3@3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -2974,6 +2988,10 @@ universal-deep-strict-equal@^1.2.1:
     array-filter "^1.0.0"
     indexof "0.0.1"
     object-keys "^1.0.0"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 url-join@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
* Add 'private' property (default: false)
* When 'private' is true, source contents are copied/published to the plugin directory (/gitbook/gitbook-plugin-github-issue-feedback/contents/).
  Plugin load contents from there instead of the Github API.

How do you think?

