### PR TITLE
fix(plugin): copy operation should be sync for 'gitbook build'

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
             if (isPrivateRepo) {
                 const source = this.config.get("root", "./")
                 const target = path.join("./_book/gitbook/gitbook-plugin-github-issue-feedback/contents", source)
-                fse.copy(source, target)
+                fse.copySync(source, target)
             }
         }
     }


### PR DESCRIPTION
I'm sorry, my last PR has a bug.

`fs-extra#copy` is an async method, so the copy operation often doesn't finish correctly for `gitbook build`. (There are no problem for `gitbook serve`)

I change the code to use `fs-extra#copySync`.

Thanks and Regards.
