### PR TITLE
fix(plugin): fetch with credentials for same origin request

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -19,7 +19,7 @@ function getContentAsync(contentURL) {
         return decodeURIComponent(escape(atob(response.content)));
     });
   } else {
-    return fetch(contentURL).then(function(response) {
+    return fetch(contentURL, { credentials: "same-origin" }).then(function(response) {
         return response.text();
     });
   }


### PR DESCRIPTION
When the plugin option is `private: true` and the document site has authentication, fetching local contents doesn't work. I added `{ credential: "same-origin" }` to fetch local contents.

Sorry for my frequent PRs. Should I have created a new plugin myself  😕 ? 