### PR TITLE
fix: content url for private repo

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,6 +39,7 @@ function getContentURL(config, filePath) {
     if (config.private) {
         return urlJoin(
             location.origin,
+            config.repo.split('/')[1],
             "gitbook/gitbook-plugin-github-issue-feedback/contents",
             filePath
         );

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,7 +39,7 @@ function getContentURL(config, filePath) {
     if (config.private) {
         return urlJoin(
             location.origin,
-            config.repo.split('/')[1],
+            /\.github\.io$/.test(config.repo) ? '' : config.repo.split('/')[1],
             "gitbook/gitbook-plugin-github-issue-feedback/contents",
             filePath
         );


### PR DESCRIPTION
When the repo is private, `getContentAsync(contentURL)` is 404 because `getContentURL(config, pathname)` generates invalid url.
So there is only file url in default PR message.
The editLink made by selection is missing.

**actual**
`https://{user}.github.io/gitbook/gitbook-plugin-github-issue-feedback/contents/{path}`

**expected**
`https://{user}.github.io/{repo_name}/gitbook/gitbook-plugin-github-issue-feedback/contents/{path}`
