### PR TITLE
feat(plugin): support label property for Bug Report button

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ For private repositories, set this flag.
 }
 ```
 
+- `label`: button label (optional, default is `Bug Report`)
+
+Set button label if you want to use other than default.
+
+```json
+{
+    "gitbook": ">=3.0.0",
+    "title": "Example",
+    "plugins": [
+        "github-issue-feedback"
+    ],
+    "pluginsConfig": {
+        "github-issue-feedback": {
+            "repo": "your/private_repo",
+            "private": true,
+            "label": "Report Issue on GitHub"
+        }
+    }
+}
+```
+
 ## Changelog
 
 See [Releases page](https://github.com/azu/gitbook-plugin-github-issue-feedback/releases).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Set button label if you want to use other than default.
     "pluginsConfig": {
         "github-issue-feedback": {
             "repo": "your/private_repo",
-            "private": true,
             "label": "Report Issue on GitHub"
         }
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -62,7 +62,7 @@ window.require(["gitbook"], function(gitbook) {
     gitbook.events.bind("start", function(e, pluginConfig) {
         var config = pluginConfig["github-issue-feedback"];
         var reportElement = document.createElement("button");
-        reportElement.textContent = "Bug Report";
+        reportElement.textContent = config["label"] || "Bug Report";
         reportElement.className = "gitbook-plugin-github-issue-feedback";
         reportElement.setAttribute("style", "position:fixed; right:0;bottom:0;");
         var clickEvent = ("ontouchstart" in window) ? "touchend" : "click";


### PR DESCRIPTION
## Summary
"Bug Report" is hardcode, so add "label" property. (This is mentioned in https://github.com/azu/gitbook-plugin-github-issue-feedback/issues/3)
And default is "Bug Report". (It's same as before)

## Motivation
close #3

Could you check me?